### PR TITLE
Clef API Traccar

### DIFF
--- a/core/api/jeeTraccar.php
+++ b/core/api/jeeTraccar.php
@@ -1,0 +1,61 @@
+<?php
+/* This file is part of Jeedom.
+ *
+ * Jeedom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jeedom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* * ***************************Includes********************************* */
+
+require_once dirname(__FILE__) . "/../../../../core/php/core.inc.php";
+    
+if (!jeedom::apiAccess(init('apikey'), 'traccar')) {
+    echo __('Clef API non valide, vous n\'êtes pas autorisé à effectuer cette action (geoloc)', __FILE__);
+    die();
+}
+    
+if (init('action') != null && init('action') === 'event') {
+    // Récupération du flux JSON
+    $content = file_get_contents('php://input');
+    $traccarEvent = json_decode($content);
+    log::add('traccar', 'debug', 'Evénement reçu, trame JSON : '. $content);
+
+    // Définition des variables
+    $traccarUniqueId = $traccarEvent->device->uniqueId;
+    $traccarEventType = $traccarEvent->event->type;
+    
+    // Récupération de l'équipement Traccar
+    $traccar = traccar::getTraccarByUniqueId($traccarUniqueId);
+    
+    // Appel de la fonction d'événement Traccar
+    if ($traccar != '') {
+        log::add('traccar', 'info', 'Reception d\'un événement '.$traccarEventType.' - tracker '.$traccarUniqueId.' - '.$traccar->getName());
+        traccar::traccarEvent($traccar, $traccarEvent);
+    }   
+}elseif (init('id') != '') { // Réception d'une position
+    // Récupération de l'équipement Traccar
+    $traccar = traccar::getTraccarByUniqueId(init('id'));    
+    if ($traccar != '') {
+        log::add('traccar', 'info', 'Reception d\'une position - tracker '.init('id').' - '.$traccar->getName());
+        // Appel de la fonction de position Traccar
+        traccar::traccarPosition($traccar, init('latitude'), init('longitude'));    
+    }
+
+}else{
+    log::add('traccar', 'error', 'Oups, verifier la configuration du serveur traccar');
+    return false;
+}
+
+return true;
+?>
+

--- a/core/class/traccar.class.php
+++ b/core/class/traccar.class.php
@@ -19,36 +19,6 @@
 require_once dirname(__FILE__) . '/../../../../core/php/core.inc.php';
 
 class traccar extends eqLogic {
-	public static function event() {
-		// Réception d'une action événement
-		if (init('action') != null && init('action') === 'event') {
-			// Récupération du flux JSON
-			$traccarEvent = json_decode(file_get_contents('php://input'));
-			
-			// Définition des variables
-			$traccarUniqueId = $traccarEvent->device->uniqueId;
-			$traccarEventType = $traccarEvent->event->type;
-			
-			// Récupération de l'équipement Traccar
-			$traccar = traccar::getTraccarByUniqueId($traccarUniqueId);
-			
-			log::add('traccar', 'info', 'Reception d\'un événement '.$traccarEventType.' - tracker '.$traccarUniqueId.' - '.$traccar->getName());
-			log::add('traccar', 'debug', 'Trame JSON : '.file_get_contents('php://input'));
-			
-			// Appel de la fonction d'événement Traccar
-			traccar::traccarEvent($traccar, $traccarEvent);
-		}
-		// Réception d'une position
-		else {
-			// Récupération de l'équipement Traccar
-			$traccar = traccar::getTraccarByUniqueId(init('id'));
-			
-			log::add('traccar', 'info', 'Reception d\'une position - tracker '.init('id').' - '.$traccar->getName());
-			
-			// Appel de la fonction de position Traccar
-			traccar::traccarPosition($traccar, init('latitude'), init('longitude'));
-		}
-	}
 	
 	// Actions sur réception d'une position
 	function traccarPosition($traccar, $latitude, $longitude) {
@@ -58,7 +28,7 @@ class traccar extends eqLogic {
 		// Vérification de l'identifiant de l'équipement Geoloc associé
 		if (null == $geolocId) {
 			log::add('traccar', 'error', 'Cet équipement n\'est pas lié à un objet Geoloc - tracker '.$traccar->getLogicalId().' - '.$traccar->getName());
-			throw new Exception(__('Traccar - cet équipement n\'est pas lié à un objet Geoloc : ', __FILE__) . $traccar->getLogicalId().' - '.$traccar->getName());
+			return;
 		}
 		
 		// Récupèration de la commande Geoloc
@@ -129,12 +99,12 @@ class traccar extends eqLogic {
 		// Vérification de l'équipement de type Traccar
 		if ($traccar->getEqType_name() != 'traccar') {
 			log::add('traccar', 'error', 'Cet équipement n\'est pas de type traccar - tracker '.$uniqueId.' - '.$traccar->getName());
-			throw new Exception(__('Traccar - cet équipement n\'est pas de type traccar : ', __FILE__) . $uniqueId.' - '.$traccar->getName());
+			return '';
 		}
 		// Vérification de l'équipement actif
 		if ($traccar->getIsEnable() != 1) {
 			log::add('traccar', 'error', 'Cet équipement n\'est pas activé - tracker '.$uniqueId.' - '.$traccar->getName());
-			throw new Exception(__('Traccar - cet équipement n\'est pas activé : ', __FILE__) . $uniqueId.' - '.$traccar->getName());
+			return '';
 		}
 		
 		return $traccar;

--- a/doc/fr_FR/configuration.asciidoc
+++ b/doc/fr_FR/configuration.asciidoc
@@ -14,14 +14,14 @@ Les commandes Traccar permettant de défnir si un équipement est présent ou no
 Du côté du serveur Traccar il faut éditer le fichier de configuration traccar.xml et ajouter les lignes :
 
 	<entry key='forward.enable'>true</entry>
-	<entry key='forward.url'>http://<IP Jeedom>:<port Jeedom>/core/api/jeeApi.php?api=<clé API>&amp;type=traccar&amp;id={uniqueId}&amp;latitude={latitude}&amp;longitude={longitude}</entry>
+	<entry key='forward.url'>http://<IP Jeedom>:<port Jeedom>/plugins/traccar/core/api/jeeTraccar.php?apikey=<clé API>&amp;type=traccar&amp;id={uniqueId}&amp;latitude={latitude}&amp;longitude={longitude}</entry>
 	
 Bien veiller à ce que les "&" soient représentés par leur code HTML "&amp;" !
 
 Remplacer :
   - <IP Jeedom> : par l'IP de la machine hébergant votre Jeedom
   - <port Jeedom> : par le port HTTP de votre Jeedom
-  - <clé API> : par la clé API de votre Jeedom disponible dans l'écran de configuration générale
+  - <clé API> : par la clé API du plugin Traccar disponible dans l'écran de configuration API
 
 Relancer ensuite le serveur Traccar pour prendre en compte les changements.
 
@@ -30,14 +30,14 @@ Relancer ensuite le serveur Traccar pour prendre en compte les changements.
 Editer le fichier de configuration traccar.xml et ajouter les lignes :
 
 	<entry key='event.forward.enable'>true</entry>
-	<entry key='event.forward.url'>http://<IP Jeedom>:<port Jeedom>/core/api/jeeApi.php?api=<clé API>&amp;type=traccar&amp;action=event</entry>
+	<entry key='event.forward.url'>http://<IP Jeedom>:<port Jeedom>/plugins/traccar/core/api/jeeTraccar.php?apikey=<clé API>&amp;type=traccar&amp;action=event</entry>
 
 Bien veiller à ce que les "&" soient représentés par leur code HTML "&amp;" !
 
 Remplacer :
   - <IP Jeedom> : par l'IP de la machine hébergant votre Jeedom
   - <port Jeedom> : par le port HTTP de votre Jeedom
-  - <clé API> : par la clé API de votre Jeedom disponible dans l'écran de configuration générale
+  - <clé API> : par la clé API du plugin Traccar disponible dans l'écran de configuration API
 
 Traccar propose un événement "deviceMoving" qui peu envoyer trop de notifications en fonction du tracker utilisé.
 

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -1,0 +1,41 @@
+<?php
+/* This file is part of Jeedom.
+ *
+ * Jeedom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jeedom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+ */
+require_once dirname(__FILE__) . '/../../../core/php/core.inc.php';
+
+function traccar_install() {
+    
+    if (config::byKey('api','traccar') == '') {
+        config::save('api', config::genKey(), 'traccar');
+    }
+
+}
+    
+function traccar_update() {
+    
+    if (config::byKey('api','traccar') == '') {
+        config::save('api', config::genKey(), 'traccar');
+    }
+    
+}
+    
+function traccar_remove() {
+
+    if (config::byKey('api','traccar') == '') {
+        config::remove('api', 'traccar');
+    }
+
+}


### PR DESCRIPTION
Bonjour Dough,
modification pour l'utilisation d'une clef API spécifique au plugin,
il faut donc modifier le fichier de config de traccar , la doc est mise à  jour. 
Pense à faire quelques tests chez toi pour voir si tout est ok, avant de mettre cette modif sur le market.